### PR TITLE
Fixed reverse geocoding, updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Then, in order to run it on a local web server, run:
 python -m SimpleHTTPServer 8000
 ```
 
-And navigate to http://localhost:8000/index.html
+And navigate to http://localhost:8000

--- a/script.js
+++ b/script.js
@@ -66,6 +66,7 @@ inputElement.placeholder = "Getting location...";
 var mapzen_key = "search-6xXbnNY";
 var auto_url = 'https://search.mapzen.com/v1/autocomplete';
 var search_url = 'https://search.mapzen.com/v1/search';
+var reverse_url = 'https://search.mapzen.com/v1/reverse';
 
 var addresses = [];
 
@@ -173,10 +174,8 @@ function searchNeighborhoods(position, neighborhoods) {
           url: reverse_url,
           data: {
             api_key: mapzen_key,
-            point: {
-              lat: position[0],
-              lon: position[1]
-            }
+            "point.lat": position[0],
+            "point.lon": position[1]
           },
           dataType: "json",
           success: function (data) {


### PR DESCRIPTION
Reverse geocoding URL (for finding neighborhood names outside Chicago) was accidentally dropped, and the API doesn't like the dot notation formatting for some reason. Added back in the URL, and changed the params back to string "point.lat" and it's working. Also removed the unnecessary "/index.html" from the README example of running it on localhost
