### PR TITLE
Fixed retina CSS selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install
 Then, in order to run it on a local web server, run:
 
 ```
-python -m SimpleHTTPServer
+python -m SimpleHTTPServer 8000
 ```
 
 And navigate to http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install
 Then, in order to run it on a local web server, run:
 
 ```
-python -m SimpleHTTPServer 8000
+python -m SimpleHTTPServer
 ```
 
 And navigate to http://localhost:8000

--- a/style.css
+++ b/style.css
@@ -79,12 +79,12 @@ b {
 }
 
 /* Override Leaflet image path CSS */
-a.leaflet-control-layers-toggle {
-	background-image: url(bower_components/leaflet/dist/images/layers.png);
+.leaflet-control-layers-toggle {
+	background-image: url('bower_components/leaflet/dist/images/layers.png');
 }
 
-a.leaflet-retina .leaflet-control-layers-toggle {
-	background-image: url(bower_components/leaflet/dist/images/layers-2x.png);
+.leaflet-retina .leaflet-control-layers-toggle {
+	background-image: url('bower_components/leaflet/dist/images/layers-2x.png');
 }
 
 /* Smartphones (portrait and landscape) ----------- */


### PR DESCRIPTION
Changed the selector for the layers toggle icon (it wasn't getting applied on mobile because the retina selector wasn't working). Also removed the redundant port argument from the example `SimpleHTTPServer`. Also added quotes on the CSS selectors, not sure if that creates issues, but it's more readable for me with syntax highlighting.

Just remembered that this had been an issue, so figured I'd finally fix it.
